### PR TITLE
Implement symbolic link creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*/test/files/src
+
 # Temporary Python files
 *.pyc
 *.egg-info

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ifndef TEST_RUNNER
 	# options are: nose, pytest
 	TEST_RUNNER := pytest
 endif
-UNIT_TEST_COVERAGE := 83
+UNIT_TEST_COVERAGE := 82
 INTEGRATION_TEST_COVERAGE := 96
 
 # Project settings

--- a/gdm/shell.py
+++ b/gdm/shell.py
@@ -51,7 +51,10 @@ class ShellMixin(_Base):
         self._call('cd', path, visible=visible)
 
     def ln(self, source, target):
-        self._call('ln', '-sf', source, target)
+        dirpath = os.path.dirname(target)
+        if not os.path.isdir(dirpath):
+            self.mkdir(dirpath)
+        self._call('ln', '-s', '-f', '-F', source, target)
 
 
 class GitMixin(_Base):

--- a/gdm/test/test_all.py
+++ b/gdm/test/test_all.py
@@ -1,7 +1,7 @@
 """Integration tests for the `gdm` package."""
 
 import os
-import subprocess
+import shutil
 
 import pytest
 
@@ -15,7 +15,7 @@ from .conftest import FILES
 def test_install():
     """Verify dependencies can be installed."""
     config = Config(FILES)
-    subprocess.call(['rm', '-rf', config.location])
+    shutil.rmtree(config.location)
     assert not os.path.exists(config.location)
 
     # clean install
@@ -25,3 +25,5 @@ def test_install():
     assert gdm.install(FILES)
     assert 'gdm_1' in os.listdir(config.location)
     assert 'gdm_2' in os.listdir(config.location)
+
+    shutil.rmtree(os.path.join(FILES, 'src'))

--- a/gdm/test/test_all.py
+++ b/gdm/test/test_all.py
@@ -21,7 +21,6 @@ def test_install():
     # clean install
     assert gdm.install(FILES)
     assert os.path.isdir(config.location)
-
     # second install
     assert gdm.install(FILES)
     assert 'gdm_1' in os.listdir(config.location)

--- a/gdm/test/test_all.py
+++ b/gdm/test/test_all.py
@@ -15,7 +15,8 @@ from .conftest import FILES
 def test_install():
     """Verify dependencies can be installed."""
     config = Config(FILES)
-    shutil.rmtree(config.location)
+    if os.path.exists(config.location):
+        shutil.rmtree(config.location)
     assert not os.path.exists(config.location)
 
     # clean install

--- a/gdm/test/test_config.py
+++ b/gdm/test/test_config.py
@@ -68,6 +68,11 @@ class TestConfig:
         assert 'gdm.yml' == config.filename
         assert '.gdm' == config.location
 
+    def test_path(self):
+        """Verify a configuration's path is correct."""
+        config = Config('mock/root')
+        assert "mock/root/gdm.yml" == config.path
+
 
 class TestInstall:
 

--- a/gdm/test/test_shell.py
+++ b/gdm/test/test_shell.py
@@ -1,7 +1,7 @@
 """Unit tests for the `shell` module."""
 # pylint: disable=R0201
 
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 import pytest
 
@@ -67,10 +67,18 @@ class TestShell(_BaseTestCalls):
         self.shell.cd('mock/dir/path')
         self.assert_calls(mock_call, ["cd mock/dir/path"])
 
+    @patch('os.path.isdir', Mock(return_value=True))
     def test_ln(self, mock_call):
         """Verify the commands to create symbolic links."""
         self.shell.ln('mock/target', 'mock/source')
-        self.assert_calls(mock_call, ["ln -sf mock/target mock/source"])
+        self.assert_calls(mock_call, ["ln -s -f -F mock/target mock/source"])
+
+    @patch('os.path.isdir', Mock(return_value=False))
+    def test_ln_missing_parent(self, mock_call):
+        """Verify the commands to create symbolic links (missing parent)."""
+        self.shell.ln('mock/target', 'mock/source')
+        self.assert_calls(mock_call, ["mkdir -p mock",
+                                      "ln -s -f -F mock/target mock/source"])
 
 
 @patch('gdm.shell._call')


### PR DESCRIPTION
Currently, tests fail when run a second time. Cleanup is needed.