### PR TITLE
Use 'rm' instead of 'remove' for 'git remote' cmds

### DIFF
--- a/gdm/shell.py
+++ b/gdm/shell.py
@@ -75,7 +75,7 @@ class GitMixin:
 
     def git_fetch(self, repo, rev=None):
         """Fetch the latest changes from the remote repository."""
-        self._git('remote', 'remove', 'origin', visible=False, ignore=True)
+        self._git('remote', 'rm', 'origin', visible=False, ignore=True)
         self._git('remote', 'add', 'origin', repo)
         args = ['fetch', '--tags', '--force', '--prune', 'origin']
         if rev:

--- a/gdm/test/test_shell.py
+++ b/gdm/test/test_shell.py
@@ -103,7 +103,7 @@ class TestGit:
         """Verify the commands to fetch from a Git repository."""
         self.shell.git_fetch('mock.git')
         assert_calls(mock_call, [
-            "git remote remove origin",
+            "git remote rm origin",
             "git remote add origin mock.git",
             "git fetch --tags --force --prune origin",
         ])
@@ -112,7 +112,7 @@ class TestGit:
         """Verify the commands to fetch from a Git repository w/ rev."""
         self.shell.git_fetch('mock.git', 'mock-rev')
         assert_calls(mock_call, [
-            "git remote remove origin",
+            "git remote rm origin",
             "git remote add origin mock.git",
             "git fetch --tags --force --prune origin mock-rev",
         ])
@@ -121,7 +121,7 @@ class TestGit:
         """Verify the commands to fetch from a Git repository w/ SHA."""
         self.shell.git_fetch('mock.git', 'abcdef1234' * 4)
         assert_calls(mock_call, [
-            "git remote remove origin",
+            "git remote rm origin",
             "git remote add origin mock.git",
             "git fetch --tags --force --prune origin",
         ])
@@ -130,7 +130,7 @@ class TestGit:
         """Verify the commands to fetch from a Git repository w/ rev-parse."""
         self.shell.git_fetch('mock.git', 'master@{2015-02-12 18:30:00}')
         assert_calls(mock_call, [
-            "git remote remove origin",
+            "git remote rm origin",
             "git remote add origin mock.git",
             "git fetch --tags --force --prune origin",
         ])


### PR DESCRIPTION
The fetch part will remove an existing remote and add a new one. The code for
removing a remote was using 'git remote remove' command, but it should have
been 'git remote rm'.

This resolves issue #81.